### PR TITLE
CPU UPDATE [added 46 new instructions]

### DIFF
--- a/emulator/src/cpu/micro_instructions.rs
+++ b/emulator/src/cpu/micro_instructions.rs
@@ -26,8 +26,21 @@ pub enum MicroInstruction {
     WriteZeroPageBalY,
     WriteAbsolute,
 
+    ClearCarryFlag,
+    ClearDecimalFlag,
+    ClearInterruptDisableFlag,
+    ClearOverflowFlag,
+    SetCarryFlag,
+    SetDecimalFlag,
+    SetInterruptDisableFlag,
+
     ShiftLeftAccumulator,
     ShiftLeftMemoryBuffer,
+
+    PushAccumulator,
+    PushStatusRegister,
+    PullAccumulator,
+    PullStatusRegister,
 
     IncrementMemoryBuffer,
     IncrementX,
@@ -51,6 +64,7 @@ pub enum MicroInstruction {
 
     And,
     Xor,
+    Or,
 }
 
 pub struct MicroInstructionSequence {

--- a/emulator/src/cpu/micro_instructions.rs
+++ b/emulator/src/cpu/micro_instructions.rs
@@ -22,8 +22,9 @@ pub enum MicroInstruction {
     ReadBahIndirectIal,
 
     WriteZeroPage,
-    WriteAbsolute,
     WriteZeroPageBalX,
+    WriteZeroPageBalY,
+    WriteAbsolute,
 
     ShiftLeftAccumulator,
     ShiftLeftMemoryBuffer,
@@ -38,8 +39,18 @@ pub enum MicroInstruction {
     LoadAccumulator,
     LoadX,
     LoadY,
+    StoreAccumulator,
+    StoreX,
+    StoreY,
+    TransferAccumulatorToX,
+    TransferAccumulatorToY,
+    TransferStackptrToX,
+    TransferXToAccumulator,
+    TransferXToStackptr,
+    TransferYToAccumulator,
 
     And,
+    Xor,
 }
 
 pub struct MicroInstructionSequence {

--- a/emulator/src/cpu/operations.rs
+++ b/emulator/src/cpu/operations.rs
@@ -6,18 +6,21 @@ pub enum Operation {
     AslZeroPage,
     AslZeroPageX,
     AslAbsolute,
+
     IncMemZeroPage,
     IncMemZeroPageX,
     IncMemAbsolute,
     IncMemAbsoluteX,
     IncX,
     IncY,
+
     DecMemZeroPage,
     DecMemZeroPageX,
     DecMemAbsolute,
     DecMemAbsoluteX,
     DecX,
     DecY,
+
     LoadAccImm,
     LoadAccZeroPage,
     LoadAccZeroPageX,
@@ -36,6 +39,28 @@ pub enum Operation {
     LoadYZeroPageX,
     LoadYAbsolute,
     LoadYAbsoluteX,
+
+    StoreAccZeroPage,
+    StoreAccZeroPageX,
+    StoreAccAbsolute,
+    StoreAccAbsoluteX,
+    StoreAccAbsoluteY,
+    StoreAccIndirectX,
+    StoreAccIndirectY,
+    StoreXZeroPage,
+    StoreXZeroPageY,
+    StoreXAbsolute,
+    StoreYZeroPage,
+    StoreYZeroPageX,
+    StoreYAbsolute,
+
+    TransferAccToX,
+    TransferAccToY,
+    TransferStackptrToX,
+    TransferXToAcc,
+    TransferXToStackptr,
+    TransferYToAcc,
+
     AndImm,
     AndZeroPage,
     AndZeroPageX,
@@ -44,6 +69,15 @@ pub enum Operation {
     AndAbsoluteY,
     AndIndirectX,
     AndIndirectY,
+
+    XorImm,
+    XorZeroPage,
+    XorZeroPageX,
+    XorAbsolute,
+    XorAbsoluteX,
+    XorAbsoluteY,
+    XorIndirectX,
+    XorIndirectY,
 }
 
 pub struct OperationMicroInstructions {
@@ -296,6 +330,133 @@ impl Operation {
                 addressing_sequence: Some(absolute_x_addressing),
                 operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::LoadY]),
             },
+            Self::StoreAccZeroPage => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteZeroPage,
+                ]),
+            },
+            Self::StoreAccZeroPageX => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteZeroPageBalX,
+                ]),
+            },
+            Self::StoreAccAbsolute => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::StoreAccAbsoluteX => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::StoreAccAbsoluteY => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::StoreAccIndirectX => OperationMicroInstructions {
+                addressing_sequence: Some(indirect_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::StoreAccIndirectY => OperationMicroInstructions {
+                addressing_sequence: Some(indirect_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreAccumulator,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::StoreXZeroPage => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreX,
+                    MicroInstruction::WriteZeroPage,
+                ]),
+            },
+            Self::StoreXZeroPageY => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreX,
+                    MicroInstruction::WriteZeroPageBalY,
+                ]),
+            },
+            Self::StoreXAbsolute => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreX,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::StoreYZeroPage => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreY,
+                    MicroInstruction::WriteZeroPage,
+                ]),
+            },
+            Self::StoreYZeroPageX => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreY,
+                    MicroInstruction::WriteZeroPageBalX,
+                ]),
+            },
+            Self::StoreYAbsolute => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::StoreY,
+                    MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::TransferAccToX => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::TransferAccumulatorToX,
+                ]),
+            },
+            Self::TransferAccToY => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::TransferAccumulatorToY,
+                ]),
+            },
+            Self::TransferStackptrToX => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::TransferStackptrToX,
+                ]),
+            },
+            Self::TransferXToAcc => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::TransferXToAccumulator,
+                ]),
+            },
+            Self::TransferXToStackptr => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::TransferXToStackptr,
+                ]),
+            },
+            Self::TransferYToAcc => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::TransferYToAccumulator,
+                ]),
+            },
             Self::AndImm => OperationMicroInstructions {
                 addressing_sequence: Some(immediate_addressing),
                 operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::And]),
@@ -327,6 +488,38 @@ impl Operation {
             Self::AndIndirectY => OperationMicroInstructions {
                 addressing_sequence: Some(indirect_y_addressing),
                 operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::And]),
+            },
+            Self::XorImm => OperationMicroInstructions {
+                addressing_sequence: Some(immediate_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorZeroPage => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorZeroPageX => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorAbsolute => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorAbsoluteX => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorAbsoluteY => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorIndirectX => OperationMicroInstructions {
+                addressing_sequence: Some(indirect_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
+            },
+            Self::XorIndirectY => OperationMicroInstructions {
+                addressing_sequence: Some(indirect_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
             },
         }
     }
@@ -367,6 +560,33 @@ impl Operation {
             Self::LoadYZeroPageX => 0xB4,
             Self::LoadYAbsolute => 0xAC,
             Self::LoadYAbsoluteX => 0xBC,
+            Self::StoreAccZeroPage => 0x85,
+            Self::StoreAccZeroPageX => 0x95,
+            Self::StoreAccAbsolute => 0x8D,
+            Self::StoreAccAbsoluteX => 0x9D,
+            Self::StoreAccAbsoluteY => 0x99,
+            Self::StoreAccIndirectX => 0x81,
+            Self::StoreAccIndirectY => 0x91,
+            Self::StoreXZeroPage => 0x86,
+            Self::StoreXZeroPageY => 0x96,
+            Self::StoreXAbsolute => 0x8E,
+            Self::StoreYZeroPage => 0x84,
+            Self::StoreYZeroPageX => 0x94,
+            Self::StoreYAbsolute => 0x8C,
+            Self::TransferAccToX => 0xAA,
+            Self::TransferAccToY => 0xA8,
+            Self::TransferStackptrToX => 0xBA,
+            Self::TransferXToAcc => 0x8A,
+            Self::TransferXToStackptr => 0x9A,
+            Self::TransferYToAcc => 0x98,
+            Self::XorImm => 0x49,
+            Self::XorZeroPage => 0x45,
+            Self::XorZeroPageX => 0x55,
+            Self::XorAbsolute => 0x4D,
+            Self::XorAbsoluteX => 0x5D,
+            Self::XorAbsoluteY => 0x59,
+            Self::XorIndirectX => 0x41,
+            Self::XorIndirectY => 0x51,
             Self::AndImm => 0x29,
             Self::AndZeroPage => 0x25,
             Self::AndZeroPageX => 0x35,
@@ -414,6 +634,33 @@ impl Operation {
             0xB4 => Some(Self::LoadYZeroPageX),
             0xAC => Some(Self::LoadYAbsolute),
             0xBC => Some(Self::LoadYAbsoluteX),
+            0x85 => Some(Self::StoreAccZeroPage),
+            0x95 => Some(Self::StoreAccZeroPageX),
+            0x8D => Some(Self::StoreAccAbsolute),
+            0x9D => Some(Self::StoreAccAbsoluteX),
+            0x99 => Some(Self::StoreAccAbsoluteY),
+            0x81 => Some(Self::StoreAccIndirectX),
+            0x91 => Some(Self::StoreAccIndirectY),
+            0x86 => Some(Self::StoreXZeroPage),
+            0x96 => Some(Self::StoreXZeroPageY),
+            0x8E => Some(Self::StoreXAbsolute),
+            0x84 => Some(Self::StoreYZeroPage),
+            0x94 => Some(Self::StoreYZeroPageX),
+            0x8C => Some(Self::StoreYAbsolute),
+            0xAA => Some(Self::TransferAccToX),
+            0xA8 => Some(Self::TransferAccToY),
+            0xBA => Some(Self::TransferStackptrToX),
+            0x8A => Some(Self::TransferXToAcc),
+            0x9A => Some(Self::TransferXToStackptr),
+            0x98 => Some(Self::TransferYToAcc),
+            0x49 => Some(Self::XorImm),
+            0x45 => Some(Self::XorZeroPage),
+            0x55 => Some(Self::XorZeroPageX),
+            0x4D => Some(Self::XorAbsolute),
+            0x5D => Some(Self::XorAbsoluteX),
+            0x59 => Some(Self::XorAbsoluteY),
+            0x41 => Some(Self::XorIndirectX),
+            0x51 => Some(Self::XorIndirectY),
             0x29 => Some(Self::AndImm),
             0x25 => Some(Self::AndZeroPage),
             0x35 => Some(Self::AndZeroPageX),

--- a/emulator/src/cpu/operations.rs
+++ b/emulator/src/cpu/operations.rs
@@ -2,10 +2,23 @@ use crate::cpu::micro_instructions::{MicroInstruction, MicroInstructionSequence}
 
 #[derive(PartialEq, Debug)]
 pub enum Operation {
+    ClearCarryFlag,
+    ClearDecimalFlag,
+    ClearInterruptDisableFlag,
+    ClearOverflowFlag,
+    SetCarryFlag,
+    SetDecimalFlag,
+    SetInterruptDisableFlag,
+
     AslA,
     AslZeroPage,
     AslZeroPageX,
     AslAbsolute,
+
+    PushAcc,
+    PushStatus,
+    PullAcc,
+    PullStatus,
 
     IncMemZeroPage,
     IncMemZeroPageX,
@@ -78,6 +91,15 @@ pub enum Operation {
     XorAbsoluteY,
     XorIndirectX,
     XorIndirectY,
+
+    OrImm,
+    OrZeroPage,
+    OrZeroPageX,
+    OrAbsolute,
+    OrAbsoluteX,
+    OrAbsoluteY,
+    OrIndirectX,
+    OrIndirectY,
 }
 
 pub struct OperationMicroInstructions {
@@ -135,6 +157,48 @@ impl Operation {
             MicroInstructionSequence::new(vec![MicroInstruction::ImmediateRead]);
 
         match self {
+            Self::ClearCarryFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::ClearCarryFlag,
+                ]),
+            },
+            Self::ClearDecimalFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::ClearDecimalFlag,
+                ]),
+            },
+            Self::ClearInterruptDisableFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::ClearInterruptDisableFlag,
+                ]),
+            },
+            Self::ClearOverflowFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::ClearOverflowFlag,
+                ]),
+            },
+            Self::SetCarryFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::SetCarryFlag,
+                ]),
+            },
+            Self::SetDecimalFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::SetDecimalFlag,
+                ]),
+            },
+            Self::SetInterruptDisableFlag => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::SetInterruptDisableFlag,
+                ]),
+            },
             Self::AslA => OperationMicroInstructions {
                 addressing_sequence: None,
                 operation_sequence: MicroInstructionSequence::new(vec![
@@ -160,6 +224,30 @@ impl Operation {
                 operation_sequence: MicroInstructionSequence::new(vec![
                     MicroInstruction::ShiftLeftMemoryBuffer,
                     MicroInstruction::WriteAbsolute,
+                ]),
+            },
+            Self::PushAcc => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::PushAccumulator,
+                ]),
+            },
+            Self::PushStatus => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::PushStatusRegister,
+                ]),
+            },
+            Self::PullAcc => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::PullAccumulator,
+                ]),
+            },
+            Self::PullStatus => OperationMicroInstructions {
+                addressing_sequence: None,
+                operation_sequence: MicroInstructionSequence::new(vec![
+                    MicroInstruction::PullStatusRegister,
                 ]),
             },
             Self::IncMemZeroPage => OperationMicroInstructions {
@@ -521,15 +609,58 @@ impl Operation {
                 addressing_sequence: Some(indirect_y_addressing),
                 operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Xor]),
             },
+            Self::OrImm => OperationMicroInstructions {
+                addressing_sequence: Some(immediate_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrZeroPage => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrZeroPageX => OperationMicroInstructions {
+                addressing_sequence: Some(zero_page_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrAbsolute => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrAbsoluteX => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrAbsoluteY => OperationMicroInstructions {
+                addressing_sequence: Some(absolute_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrIndirectX => OperationMicroInstructions {
+                addressing_sequence: Some(indirect_x_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
+            Self::OrIndirectY => OperationMicroInstructions {
+                addressing_sequence: Some(indirect_y_addressing),
+                operation_sequence: MicroInstructionSequence::new(vec![MicroInstruction::Or]),
+            },
         }
     }
 
     pub fn get_opcode(&self) -> u8 {
         match self {
+            Self::ClearCarryFlag => 0x18,
+            Self::ClearDecimalFlag => 0xD8,
+            Self::ClearInterruptDisableFlag => 0x58,
+            Self::ClearOverflowFlag => 0xB8,
+            Self::SetCarryFlag => 0x38,
+            Self::SetDecimalFlag => 0xF8,
+            Self::SetInterruptDisableFlag => 0x78,
             Self::AslA => 0x0A,
             Self::AslZeroPage => 0x06,
             Self::AslZeroPageX => 0x16,
             Self::AslAbsolute => 0x0E,
+            Self::PushAcc => 0x48,
+            Self::PushStatus => 0x08,
+            Self::PullAcc => 0x68,
+            Self::PullStatus => 0x28,
             Self::IncMemZeroPage => 0xE6,
             Self::IncMemZeroPageX => 0xF6,
             Self::IncMemAbsolute => 0xEE,
@@ -579,14 +710,6 @@ impl Operation {
             Self::TransferXToAcc => 0x8A,
             Self::TransferXToStackptr => 0x9A,
             Self::TransferYToAcc => 0x98,
-            Self::XorImm => 0x49,
-            Self::XorZeroPage => 0x45,
-            Self::XorZeroPageX => 0x55,
-            Self::XorAbsolute => 0x4D,
-            Self::XorAbsoluteX => 0x5D,
-            Self::XorAbsoluteY => 0x59,
-            Self::XorIndirectX => 0x41,
-            Self::XorIndirectY => 0x51,
             Self::AndImm => 0x29,
             Self::AndZeroPage => 0x25,
             Self::AndZeroPageX => 0x35,
@@ -595,15 +718,42 @@ impl Operation {
             Self::AndAbsoluteY => 0x39,
             Self::AndIndirectX => 0x21,
             Self::AndIndirectY => 0x31,
+            Self::XorImm => 0x49,
+            Self::XorZeroPage => 0x45,
+            Self::XorZeroPageX => 0x55,
+            Self::XorAbsolute => 0x4D,
+            Self::XorAbsoluteX => 0x5D,
+            Self::XorAbsoluteY => 0x59,
+            Self::XorIndirectX => 0x41,
+            Self::XorIndirectY => 0x51,
+            Self::OrImm => 0x09,
+            Self::OrZeroPage => 0x05,
+            Self::OrZeroPageX => 0x15,
+            Self::OrAbsolute => 0x0D,
+            Self::OrAbsoluteX => 0x1D,
+            Self::OrAbsoluteY => 0x19,
+            Self::OrIndirectX => 0x01,
+            Self::OrIndirectY => 0x11,
         }
     }
 
     pub fn get_operation(opcode: u8) -> Option<Self> {
         match opcode {
+            0x18 => Some(Self::ClearCarryFlag),
+            0xD8 => Some(Self::ClearDecimalFlag),
+            0x58 => Some(Self::ClearInterruptDisableFlag),
+            0xB8 => Some(Self::ClearOverflowFlag),
+            0x38 => Some(Self::SetCarryFlag),
+            0xF8 => Some(Self::SetDecimalFlag),
+            0x78 => Some(Self::SetInterruptDisableFlag),
             0x0A => Some(Self::AslA),
             0x06 => Some(Self::AslZeroPage),
             0x16 => Some(Self::AslZeroPageX),
             0x0E => Some(Self::AslAbsolute),
+            0x48 => Some(Self::PushAcc),
+            0x08 => Some(Self::PushStatus),
+            0x68 => Some(Self::PullAcc),
+            0x28 => Some(Self::PullStatus),
             0xE6 => Some(Self::IncMemZeroPage),
             0xF6 => Some(Self::IncMemZeroPageX),
             0xEE => Some(Self::IncMemAbsolute),
@@ -653,14 +803,6 @@ impl Operation {
             0x8A => Some(Self::TransferXToAcc),
             0x9A => Some(Self::TransferXToStackptr),
             0x98 => Some(Self::TransferYToAcc),
-            0x49 => Some(Self::XorImm),
-            0x45 => Some(Self::XorZeroPage),
-            0x55 => Some(Self::XorZeroPageX),
-            0x4D => Some(Self::XorAbsolute),
-            0x5D => Some(Self::XorAbsoluteX),
-            0x59 => Some(Self::XorAbsoluteY),
-            0x41 => Some(Self::XorIndirectX),
-            0x51 => Some(Self::XorIndirectY),
             0x29 => Some(Self::AndImm),
             0x25 => Some(Self::AndZeroPage),
             0x35 => Some(Self::AndZeroPageX),
@@ -669,6 +811,22 @@ impl Operation {
             0x39 => Some(Self::AndAbsoluteY),
             0x21 => Some(Self::AndIndirectX),
             0x31 => Some(Self::AndIndirectY),
+            0x49 => Some(Self::XorImm),
+            0x45 => Some(Self::XorZeroPage),
+            0x55 => Some(Self::XorZeroPageX),
+            0x4D => Some(Self::XorAbsolute),
+            0x5D => Some(Self::XorAbsoluteX),
+            0x59 => Some(Self::XorAbsoluteY),
+            0x41 => Some(Self::XorIndirectX),
+            0x51 => Some(Self::XorIndirectY),
+            0x09 => Some(Self::OrImm),
+            0x05 => Some(Self::OrZeroPage),
+            0x15 => Some(Self::OrZeroPageX),
+            0x0D => Some(Self::OrAbsolute),
+            0x1D => Some(Self::OrAbsoluteX),
+            0x19 => Some(Self::OrAbsoluteY),
+            0x01 => Some(Self::OrIndirectX),
+            0x11 => Some(Self::OrIndirectY),
             _ => None,
         }
     }


### PR DESCRIPTION
Added following CPU instructions:
* STA (7 addressing modes)
* STX (3 addressing modes)
* STY (3 addressing modes)
* TAX (1 addressing mode)
* TAY (1 addressing mode)
* TSX (1 addressing mode)
* TXA (1 addressing mode)
* TXS (1 addressing mode)
* TYS (1 addressing mode)
* EOR (8 addressing modes)
* CLC (1 addressing mode)
* CLD (1 addressing mode)
* CLI (1 addressing mode)
* CLV (1 addressing mode)
* SEC (1 addressing mode)
* SED (1 addressing mode)
* SEI (1 addressing mode)
* PHA (1 addressing mode)
* PHP (1 addressing mode)
* PLA (1 addressing mode)
* PLP (1 addressing mode)
* ORA (8 addressing modes)